### PR TITLE
Lesson-3

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -2,7 +2,12 @@ import React from 'react'
 
 class App extends React.Component {
   render() {
-    return <h1>hello with class!</h1>
+    return (
+      <div>
+        <h1>hello with brackets!</h1>
+        <b>bold text</b>
+      </div>
+    )
   }
 }
 


### PR DESCRIPTION
### やったこと

https://egghead.io/lessons/react-the-render-method

- return できるのは１度に１つの要素のみ
    - 関数の戻り値を複数設定できないのと同じ理屈
- return のあと `()` を置くと長いコードでもわかりやすく書ける
- return の直後に `()` なしでいきなりタグを書いても動く
    - が、 return の後に改行が入るとダメ
    - なので `()` を置くのがおすすめ