### PR TITLE
Lesson-4

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -12,7 +12,4 @@ class App extends React.Component {
   }
 }
 
-// stateless component sample
-// const App = () => <h1>hello with const!</h1>
-
 export default App

--- a/src/App.js
+++ b/src/App.js
@@ -17,4 +17,8 @@ App.propTypes = {
   cat: React.PropTypes.number.isRequired,
 }
 
+App.defaultProps = {
+  txt: "this is the default text",
+}
+
 export default App

--- a/src/App.js
+++ b/src/App.js
@@ -12,4 +12,9 @@ class App extends React.Component {
   }
 }
 
+App.propTypes = {
+  txt: React.PropTypes.string,
+  cat: React.PropTypes.number.isRequired,
+}
+
 export default App

--- a/src/App.js
+++ b/src/App.js
@@ -4,7 +4,7 @@ class App extends React.Component {
   render() {
     return (
       <div>
-        <h1>hello with brackets!</h1>
+        <h1>{this.props.txt}</h1>
         <b>bold text</b>
       </div>
     )

--- a/src/App.js
+++ b/src/App.js
@@ -2,9 +2,10 @@ import React from 'react'
 
 class App extends React.Component {
   render() {
+    let txt = this.props.txt
     return (
       <div>
-        <h1>{this.props.txt}</h1>
+        <h1>{txt}</h1>
         <b>bold text</b>
       </div>
     )

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,6 @@ import ReactDOM from 'react-dom'
 import App from './App'
 
 ReactDOM.render(
-  <App txt="this is the prop text" />,
+  <App txt="this is the prop value" />,
   document.getElementById('root'),
 );

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,6 @@ import ReactDOM from 'react-dom'
 import App from './App'
 
 ReactDOM.render(
-  <App txt="this is the prop value" />,
+  <App txt="this is the prop value" cat={5} />,
   document.getElementById('root'),
 );

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,6 @@ import ReactDOM from 'react-dom'
 import App from './App'
 
 ReactDOM.render(
-  <App />,
+  <App txt="this is the prop text" />,
   document.getElementById('root'),
 );

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,6 @@ import ReactDOM from 'react-dom'
 import App from './App'
 
 ReactDOM.render(
-  <App txt="this is the prop value" cat={5} />,
+  <App cat={5} />,
   document.getElementById('root'),
 );


### PR DESCRIPTION
### やったこと

https://egghead.io/lessons/react-introduction-to-properties

- Props を使う
    - React コンポーネントを作成する時に渡す何らかの値
    - `<App txt={value} />` みたいに渡す
    - `this.props.{name}` でアクセス
    -　『Propsをコンポーネント内で変更するべきではない』（してはいけない？）
- ローカル変数にも入れられる（普通にJS）
- propTypes で型を決められる
    - 違う型のものも入れられはするし動くけどエラーがコンソールに出力される
    - 15.5.0 から deprecated になったので使わないほうが良さそう
    - prop-types module 使えと言われる
    - Typescript 使えばいい話かもしれない？
- defaultProps でデフォルト値を設定できる