### PR TITLE
Lesson 6

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -18,7 +18,15 @@ class App extends React.Component {
     return (
       <div>
         <h1>{this.state.text}</h1>
-        <Widget update={this.update.bind(this)} />
+        { /* <Widget update={this.update.bind(this)} /> */ }
+        <Widget update={
+            (e) => {
+              this.setState({
+                text: e.target.value,
+              })
+            }
+          } 
+        />
       </div>
     )
   }

--- a/src/App.js
+++ b/src/App.js
@@ -15,7 +15,6 @@ class App extends React.Component {
   }
 
   render() {
-    let txt = this.props.txt
     return (
       <div>
         <h1>{this.state.text}</h1>
@@ -24,15 +23,6 @@ class App extends React.Component {
       </div>
     )
   }
-}
-
-App.propTypes = {
-  txt: React.PropTypes.string,
-  cat: React.PropTypes.number.isRequired,
-}
-
-App.defaultProps = {
-  txt: "this is the default text",
 }
 
 export default App

--- a/src/App.js
+++ b/src/App.js
@@ -18,11 +18,13 @@ class App extends React.Component {
     return (
       <div>
         <h1>{this.state.text}</h1>
-        <b>bold text</b>
-        <input type="text" onChange={this.update.bind(this)} />
+        <Widget update={this.update.bind(this)} />
       </div>
     )
   }
 }
+
+const Widget = (props) => 
+  <input type="text" onChange={props.update} />
 
 export default App


### PR DESCRIPTION
### やったこと

https://egghead.io/lessons/react-owner-ownee-relationship

- 子 React コンポーネントの作成
    - input 要素をコンポーネントとして切り出して使ってみる
    - Widget と名付けた単純な Const として定義
    - props でイベントハンドラを渡している。 onChange でその渡されたイベントハンドラを使う。
    - なのでイベントハンドラにば bind 済みの関数を渡している
- 試しにアロー関数でイベントハンドラを置き換えてみたけど見づらくなった
    - アロー関数は「thisを束縛しない」らしく、 `bind` をしなくても勝手に想定した挙動をする
    - https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/arrow_functions
    - > アロー関数は this を束縛しないので、this は関数を囲っている外での this を意味します
    - render メソッド内でアロー関数を使った時の this はその外側の App を指してくれる…っぽい。
        - が、デバッガで見ると undefined になっている謎。