### PR TITLE
Lesson 8 - Add Custom propType Validation to React Components -

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -2,14 +2,14 @@ import React from 'react'
 
 class App extends React.Component {
   render() {
-    return <Title />
+    return <Title text='tesT'/>
   }
 }
 
 const Title = (props) => <h1>Title: {props.text}</h1>
 
 Title.propTypes = {
-  text(props, propName, component) {
+  text: function(props, propName, component) {
     if(!(propName in props)) {
       return new Error(`missing prop: ${propName}`)
     }

--- a/src/App.js
+++ b/src/App.js
@@ -1,17 +1,6 @@
 import React from 'react'
 
 class App extends React.Component {
-  render() {
-    return <Button>I <Heart /> React</Button>
-  }
-}
-
-const Button = (props) => <button>{props.children}</button> 
-
-class Heart extends React.Component {
-  render() {
-    return <span>&hearts;</span>
-  }
 }
 
 export default App

--- a/src/App.js
+++ b/src/App.js
@@ -9,7 +9,11 @@ class App extends React.Component {
 const Title = (props) => <h1>Title: {props.text}</h1>
 
 Title.propTypes = {
-  text: React.PropTypes.string.required
+  text(props, propName, component) {
+    if(!(propName in props)) {
+      return new Error(`missing prop: ${propName}`)
+    }
+  }
 }
 
 export default App

--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,15 @@
 import React from 'react'
 
 class App extends React.Component {
+  render() {
+    return <Title />
+  }
+}
+
+const Title = (props) => <h1>Title: {props.text}</h1>
+
+Title.propTypes = {
+  text: React.PropTypes.string.required
 }
 
 export default App


### PR DESCRIPTION
### やったこと

https://egghead.io/lessons/react-custom-proptype-validation

- カスタムバリデータの追加
- propTypes を使うのは同じ。多分これも Deprecated。
- ビデオで出てくる書き方もできるけどなんか直感的じゃないので公式ドキュメントの通りに書きなおした。
    - `text(props, ...) {}` で動作するのが割と謎。JSの仕様的にそう書けるのは分からなくはないけど…
